### PR TITLE
Fix h2 driver tests

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.5.5

--- a/src/test/scala/ExampleWorkflowSpec.scala
+++ b/src/test/scala/ExampleWorkflowSpec.scala
@@ -10,9 +10,13 @@ import uk.gov.nationalarchives.pdi.test.helpers.IOHelper.delete
 import uk.gov.nationalarchives.pdi.test.{DatabaseManager, QueryManager, WorkflowManager}
 
 import java.nio.file.{Files, Paths}
+import java.sql.DriverManager
 import scala.util.{Failure, Success, Using}
 
 class ExampleWorkflowSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  // TODO(AR) this is a workaround for the driver being unregistered after the first run of the tests in sbt -- see https://stackoverflow.com/questions/14033629/playframework-2-0-scala-no-suitable-driver-found-in-tests
+  DriverManager.registerDriver(new org.h2.Driver)
 
   private val exampleWorkflow = "example.ktr"
   private val outputDirectory = "output"

--- a/src/test/scala/uk/gov/nationalarchives/pdi/test/DatabaseManagerSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/pdi/test/DatabaseManagerSpec.scala
@@ -10,9 +10,12 @@ import uk.gov.nationalarchives.pdi.test.helpers.IOHelper.delete
 import java.io.IOException
 import java.nio.file.{FileVisitResult, Files, Path, Paths, SimpleFileVisitor}
 import java.nio.file.attribute.BasicFileAttributes
-import java.sql.SQLException
+import java.sql.{DriverManager, SQLException}
 
 class DatabaseManagerSpec extends AnyWordSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
+
+  // TODO(AR) this is a workaround for the driver being unregistered after the first run of the tests in sbt -- see https://stackoverflow.com/questions/14033629/playframework-2-0-scala-no-suitable-driver-found-in-tests
+  DriverManager.registerDriver(new org.h2.Driver)
 
   private val databaseDir = "./data-dir2"
   private val databaseName = "test-db"


### PR DESCRIPTION
Workaround to allow running `test` multiple times from sbt, previously the H2 driver somehow became unregistered.