### PR TITLE
Pact 549 - Creation of a new sbt command format and commit

### DIFF
--- a/.sbtrc
+++ b/.sbtrc
@@ -1,3 +1,3 @@
 alias fmt=;scalafmt;Test / scalafmt;scalafmtSbt
 alias fmtCheck=;scalafmtCheck;Test / scalafmtCheck;scalafmtSbtCheck
-alias formatAndCommit=;clean;fmt;git add -A;git commit --allow-empty -m \"Formatting files before pushing them to remote\"
+alias formatAndCommit=;clean;fmt;git add -A;git commit --allow-empty -m "Formatting files before pushing them to remote"

--- a/.sbtrc
+++ b/.sbtrc
@@ -1,2 +1,4 @@
 alias fmt=;scalafmt;Test / scalafmt;scalafmtSbt
 alias fmtCheck=;scalafmtCheck;Test / scalafmtCheck;scalafmtSbtCheck
+alias formatAndCommit=;clean;fmt;git add -A;git commit --allow-empty -m \"Formatting files before pushing them to remote\"
+)

--- a/.sbtrc
+++ b/.sbtrc
@@ -1,4 +1,3 @@
 alias fmt=;scalafmt;Test / scalafmt;scalafmtSbt
 alias fmtCheck=;scalafmtCheck;Test / scalafmtCheck;scalafmtSbtCheck
 alias formatAndCommit=;clean;fmt;git add -A;git commit --allow-empty -m \"Formatting files before pushing them to remote\"
-)

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ To ensure that your Kettle transformations are suitable for testing it is import
 1. Run `sbt clean release`
 2. Answer the questions
 3. Login to https://oss.sonatype.org/ then Close, and Release the Staging Repository
+
+## Git Hooks
+
+It is recommended for developers to make use of the 'formatAndCommit' alias command as part of a pre-push git hook in order to make sure the code is properly formatted before pushing it to remote. CTD projects are now configured to fail git actions if code is not properly formatted, so in order to avoid this a git hook is handly.
+
+In order to create the hook you need to go to the following path '.git/hooks' and create a new script file called 'pre-push' containing just a single line 'sbt formatAndCommit'. This file should have execution permissions.

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,9 @@ val pentahoVersion = "9.1.0.0-324"
 
 ThisBuild / versionScheme := Some("semver-spec")
 
+enablePlugins(GitBranchPrompt)
+enablePlugins(GitPlugin)
+
 lazy val root = Project("kettle-test-framework", file("."))
   .configs(IntegrationTest)
   .settings(
@@ -101,3 +104,11 @@ lazy val root = Project("kettle-test-framework", file("."))
       pushChanges
     )
   )
+
+addCommandAlias(
+  "formatAndCommit",
+  "; clean " +
+    "; fmt " +
+    "; git add -A" +
+    "; git commit -m \"Formatting files before pushing them to remote\""
+)

--- a/build.sbt
+++ b/build.sbt
@@ -110,5 +110,5 @@ addCommandAlias(
   "; clean " +
     "; fmt " +
     "; git add -A" +
-    "; git commit -m \"Formatting files before pushing them to remote\""
+    "; git diff-index --quiet HEAD || git commit -m \"Formatting files before pushing them to remote\""
 )

--- a/build.sbt
+++ b/build.sbt
@@ -110,5 +110,5 @@ addCommandAlias(
   "; clean " +
     "; fmt " +
     "; git add -A" +
-    "; git diff-index --quiet HEAD || git commit -m \"Formatting files before pushing them to remote\""
+    "; git commit --allow-empty -m \"Formatting files before pushing them to remote\""
 )

--- a/build.sbt
+++ b/build.sbt
@@ -104,11 +104,3 @@ lazy val root = Project("kettle-test-framework", file("."))
       pushChanges
     )
   )
-
-addCommandAlias(
-  "formatAndCommit",
-  "; clean " +
-    "; fmt " +
-    "; git add -A" +
-    "; git commit --allow-empty -m \"Formatting files before pushing them to remote\""
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,4 @@ addSbtPlugin("com.github.sbt"    % "sbt-pgp"                            % "2.1.2
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"                       % "3.9.10")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"                         % "5.6.0")
 addSbtPlugin("com.github.sbt"    % "sbt-release"                        % "1.1.0")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-git"                            % "1.0.2")

--- a/src/test/scala/ExampleWorkflowSpec.scala
+++ b/src/test/scala/ExampleWorkflowSpec.scala
@@ -33,7 +33,8 @@ import java.nio.file.{ Files, Paths }
 import java.sql.DriverManager
 import scala.util.{ Failure, Success, Using }
 
-class ExampleWorkflowSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class ExampleWorkflowSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll
+{
 
   // TODO(AR) this is a workaround for the driver being unregistered after the first run of the tests in sbt -- see https://stackoverflow.com/questions/14033629/playframework-2-0-scala-no-suitable-driver-found-in-tests
   DriverManager.registerDriver(new org.h2.Driver)

--- a/src/test/scala/ExampleWorkflowSpec.scala
+++ b/src/test/scala/ExampleWorkflowSpec.scala
@@ -33,8 +33,7 @@ import java.nio.file.{ Files, Paths }
 import java.sql.DriverManager
 import scala.util.{ Failure, Success, Using }
 
-class ExampleWorkflowSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll
-{
+class ExampleWorkflowSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   // TODO(AR) this is a workaround for the driver being unregistered after the first run of the tests in sbt -- see https://stackoverflow.com/questions/14033629/playframework-2-0-scala-no-suitable-driver-found-in-tests
   DriverManager.registerDriver(new org.h2.Driver)


### PR DESCRIPTION
A new sbt command has been created, after adding sbt-git as a plugin, that will clean, format and create a new commit with formatting.

The intent behind this new command is to be used as part of a 'pre-push' git hook script which will contain a one line command

git formatAndCommit

This git hook will automatically format the code before pushing so that unformatted code never makes it to a remote repository.